### PR TITLE
[Refactor] drop misleading auto_activate field on SkillRecommendation

### DIFF
--- a/claude_ctx_py/skill_recommender.py
+++ b/claude_ctx_py/skill_recommender.py
@@ -29,7 +29,6 @@ class SkillRecommendation:
     triggers: List[str]
     related_agents: List[str]
     estimated_value: str  # "high", "medium", "low"
-    auto_activate: bool  # Activate if confidence >= 0.8
 
     def should_notify(self) -> bool:
         """Determine if this recommendation should notify the user."""
@@ -380,7 +379,6 @@ class SkillRecommender:
                             triggers=file_patterns,
                             related_agents=[],
                             estimated_value=self._estimate_value(rec_data["confidence"]),
-                            auto_activate=rec_data["confidence"] >= 0.8
                         )
                         recommendations.append(rec)
 
@@ -403,7 +401,6 @@ class SkillRecommender:
                         triggers=[f"agent:{agent_name}"],
                         related_agents=[agent_name],
                         estimated_value=self._estimate_value(confidence),
-                        auto_activate=confidence >= 0.8
                     )
                     recommendations.append(rec)
 
@@ -452,7 +449,6 @@ class SkillRecommender:
                         triggers=["semantic_match"],
                         related_agents=[],
                         estimated_value=self._estimate_value(confidence),
-                        auto_activate=False,
                     )
                 )
 
@@ -518,7 +514,6 @@ class SkillRecommender:
                     triggers=["historical_pattern"],
                     related_agents=[],
                     estimated_value=self._estimate_value(confidence),
-                    auto_activate=False  # Never auto-activate pattern-based
                 )
                 recommendations.append(rec)
 


### PR DESCRIPTION
## Summary

Skill activation was deprecated in favour of progressive disclosure — skills are surfaced via descriptions in context rather than being explicitly activated. The `auto_activate: bool` field on `SkillRecommendation` was a vestige of that older model:

- It was set at construction time (four sites in `skill_recommender.py`)
- It was **never read** by any consumer — the skill formatter (`_print_skill_recommendations`) groups results into High/Medium/Low confidence tiers and never referenced this field
- The `[AUTO]` badge in `cmd_suggest.py` belongs to `_print_agent_recommendations` / `AgentRecommendation`, not the skill path

A user reading `cortex suggest --skills` could reasonably infer that `[AUTO]` means a skill will be turned on for them. Nothing happens. This PR removes the field for truth-in-advertising.

**Agent activation path is untouched.** `cmd_ai.py`, `intelligence/base.py` (`AgentRecommendation.auto_activate`), `watch.py` daemon — all unchanged.

Follow-up to 6f854cd `feat(skills): add project-signature pre-filter`.

## Changes

- Removed `auto_activate: bool` field from `SkillRecommendation` dataclass (`skill_recommender.py:32`)
- Removed four `auto_activate=…` constructor kwargs (rule-based, agent-based, semantic, and pattern-based recommendation strategies)
- No changes to `cmd_suggest.py` — the `[AUTO]` badge there was already correctly scoped to `AgentRecommendation`
- No test changes needed — no test referenced `SkillRecommendation.auto_activate`

## Test plan

- [x] `pytest tests/unit/test_cmd_suggest.py` — 31 passed
- [x] `pytest tests/unit/` — 273 passed, 3 pre-existing failures (missing `psutil`/`rich` deps, unrelated to this change)
- [x] `mypy --strict claude_ctx_py/skill_recommender.py claude_ctx_py/cmd_suggest.py` — all errors in pre-existing TUI modules, none in touched files
- [x] `grep -rn auto_activate claude_ctx_py/cmd_ai.py` — agent path unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_016LLNPeb6LksE7G7Nci9rfJ)_